### PR TITLE
Added few macOS version names

### DIFF
--- a/lib/versions
+++ b/lib/versions
@@ -49,6 +49,10 @@ versions_osName() {
         10.11|10.11.[0-9]*) os_name_='Mac OS X El Capitan' ;;
         10.12|10.12.[0-9]*) os_name_='macOS Sierra' ;;
         10.13|10.13.[0-9]*) os_name_='macOS High Sierra' ;;
+        10.14|10.14.[0-9]*) os_name_='macOS Mojave' ;;
+        10.15|10.15.[0-9]*) os_name_='macOS Catalina' ;;
+        10.16|10.16.[0-9]*) os_name_='macOS Big Sur' ;;
+        11.0|11.0.[0-9]*) os_name_='macOS Big Sur ' ;;
         *) os_name_='macOS' ;;
       esac
       ;;


### PR DESCRIPTION
Mojave, Catalina, Big Sur

Big Sur is there twice, because sometimes it can present itself as 11.00 as well as 10.16.